### PR TITLE
Changed the way falling works to be decoupled form list logic

### DIFF
--- a/Assets/Prefab/Orbs/MagicalOrb.prefab
+++ b/Assets/Prefab/Orbs/MagicalOrb.prefab
@@ -223,6 +223,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   orbScript: {fileID: 0}
   curState: 0
+  TargetPos: {x: 0, y: 0, z: 0}
 --- !u!1 &9169049552108839516
 GameObject:
   m_ObjectHideFlags: 0
@@ -303,7 +304,7 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 1
+  m_MaskInteraction: 0
   m_SpriteSortPoint: 1
 --- !u!95 &6203250885290521470
 Animator:

--- a/Assets/Prefab/Orbs/MagicalOrb.prefab
+++ b/Assets/Prefab/Orbs/MagicalOrb.prefab
@@ -304,7 +304,7 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
+  m_MaskInteraction: 1
   m_SpriteSortPoint: 1
 --- !u!95 &6203250885290521470
 Animator:

--- a/Assets/ScriptableObjects/Patterns/Pattern.asset
+++ b/Assets/ScriptableObjects/Patterns/Pattern.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e34b602ae002c224e8fc49aa8473e612, type: 3}
+  m_Name: Pattern
+  m_EditorClassIdentifier: 
+  lines: []

--- a/Assets/ScriptableObjects/Patterns/Pattern.asset.meta
+++ b/Assets/ScriptableObjects/Patterns/Pattern.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 990cfeb4691bb9e4e9ed3ecbe771c9ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scripts/BoardManager.cs
+++ b/Assets/scripts/BoardManager.cs
@@ -39,7 +39,7 @@ public class BoardManager : MonoBehaviour
     public float popOrbsTimer = POPTIMERMAX;
     public bool CurrentlyPoping;
     public float ChainTimer;
-
+    public float DropSpeed;
     public float PopTimer = POPTIMERMAX;
 
 
@@ -107,7 +107,7 @@ public class BoardManager : MonoBehaviour
         {
             Debug.unityLogger.Log("Genreal", "Lines Moving down");
             DropLine(1);
-            timeUntilDrop = 5f;
+            timeUntilDrop = DropSpeed;
         }
 
         // the countdown text 
@@ -338,7 +338,7 @@ public class BoardManager : MonoBehaviour
                     {
                         orb.transform.GetChild(0).position = Vector3.Lerp(currentPos,
                                                               new Vector3(currentPos.x,
-                                                                           orb.transform.position.y,
+                                                                           orb.transform.position.y - 0.4f,
                                                                            currentPos.z),
                                                              Mathf.Clamp((elapsedTime / waitTime), 0, 1));
                     }
@@ -354,7 +354,7 @@ public class BoardManager : MonoBehaviour
                 {
                     orb.transform.GetChild(0).position = Vector3.Lerp(currentPos,
                                                               new Vector3(currentPos.x,
-                                                                           orb.transform.position.y,
+                                                                           orb.transform.position.y - 0.4f,
                                                                            currentPos.z),
                                                              1);
                 }


### PR DESCRIPTION
Falling items are now automatically put at the end of the list. This removes all race conditions that could cause trouble and made the process of editing the animations a lot simpler. This also fixes the main bug of this particular issue

the infinite loop was due to a race condition that would sometimes cause us to infinity check to see if a nonexistent orb was ready to pop. 